### PR TITLE
remove hard-coded path in Generic/SFTs/MigrationModel tests

### DIFF
--- a/Regression/regression_runner.py
+++ b/Regression/regression_runner.py
@@ -149,11 +149,12 @@ class MyRegressionRunner(object):
     def copy_one_climate_and_migration_file(self, key, filename,
                                             simulation_directory, source_input_directory,
                                             working_input_directory, scenario):
+
         source = os.path.join(source_input_directory, filename)
         dest = os.path.join(working_input_directory, os.path.basename(filename))
         scenario_file = os.path.join(scenario, filename)
 
-        # For any demographics overlays WITHIN regression folder:
+        # if the file is in the scenario folder
         # Copy directly to remote simulation working directory
         if os.path.isfile(scenario_file):
             simulation_path = os.path.join(self.params.sim_root, simulation_directory)
@@ -163,6 +164,7 @@ class MyRegressionRunner(object):
 
         if (source != dest) and (not self.update_file(source, dest)):
             print("Could not find input file '{0}' to copy to '{1}' for scenario '{2}'".format(source, dest, scenario))
+
         if key != "Load_Balance_Filename":
             source = source + ".json"
             dest = dest + ".json"
@@ -259,6 +261,7 @@ class MyRegressionRunner(object):
                 print("Creating " + working_input_directory)
                 os.makedirs(working_input_directory)
 
+        config_json["input_directory"] = working_input_directory
         # Harmonizing these to do the same thing
         self.copy_demographics_files_to_user_input(simulation_directory, config_json, working_input_directory, scenario_path, source_input_directory) 
         self.copy_climate_and_migration_files_to_user_input(simulation_directory, config_json, source_input_directory, working_input_directory, scenario_path) 
@@ -458,17 +461,17 @@ class MyRegressionRunner(object):
         if "campaign_json" in reply_json:
             #campaign_json = json.dumps(reply_json["campaign_json"]).replace("u'", "'").replace("'", '"').strip('"')
             with open( sim_dir + "/" + self.campaign_filename, 'w' ) as camp_file:
-                 try:
-                    camp_json = reply_json["campaign_json"]
-                    if isinstance( camp_json, dict ):
-                        json.dump(camp_json, camp_file)
-                    else:
-                        camp_json_grrr = json.loads( camp_json )
-                        json.dump(camp_json_grrr , camp_file)
-                 except Exception as ex:
-                     print( "Exception writing campaign.json for " + scenario_path )
-                     print( str( ex ) ) 
-            #reply_json["campaign_json"] = None 
+                    if ("campaign_json" in reply_json) and (reply_json["campaign_json"] is not None):
+                        try:
+                            camp_json = reply_json["campaign_json"]
+                            if isinstance( camp_json, dict ):
+                                json.dump(camp_json, camp_file)
+                            else:
+                                camp_json_grrr = json.loads( camp_json )
+                                json.dump(camp_json_grrr , camp_file)
+                        except Exception as ex:
+                            print( "Exception writing campaign.json for " + scenario_path )
+                            print( str( ex ) )
         elif "Campaign_Filename" in reply_json["parameters"]:
             camp_filename = reply_json["parameters"]["Campaign_Filename"]
             if len(camp_filename) > 0:

--- a/Regression/shared_embedded_py_scripts/dtk_test/dtk_MigrationModel_Support.py
+++ b/Regression/shared_embedded_py_scripts/dtk_test/dtk_MigrationModel_Support.py
@@ -11,12 +11,6 @@ import dtk_test.dtk_sft as sft
 
 # DEVNOTE: add contact to point to input path, although we should probably interrogate the environment to get the
 # input_path passed to dtk
-if os.name == "nt":
-    INPUT_PATH = "\\\\iazdvfil05.idmhpc.azr\\IDM\\home\\IDM_Bamboo_User\\input\\MigrationSFTs"
-else:
-    INPUT_PATH = "/mnt/iazdvfil05/public/input/TIP/MigrationSFTs"
-
-# INPUT_PATH = "C:\\EMOD\\USER_input_data\\MigrationTest"
 
 KEY_TOTAL_TIMESTEPS = "Simulation_Duration"
 KEY_SIMULATION_TIMESTEP = "Simulation_Timestep"
@@ -76,16 +70,18 @@ def load_emod_parameters(config_filename="config.json"):
     :returns param_obj:     dictionary with KEY_TOTAL_TIMESTEPS, etc., keys (e.g.)
     """
     with open(config_filename) as infile:
-        cdj = json.load(infile)["parameters"]
+        config = json.load(infile)
+        cdj = config["parameters"]
     param_obj = {}
+    param_obj["input_directory"] = config["input_directory"]
     param_obj[KEY_TOTAL_TIMESTEPS] = cdj[KEY_TOTAL_TIMESTEPS]
     param_obj[KEY_SIMULATION_TIMESTEP] = cdj[KEY_SIMULATION_TIMESTEP]
     param_obj[KEY_MIGRATION_MODEL] = cdj[KEY_MIGRATION_MODEL]
     param_obj[KEY_MIGRATION_PATTERN] = cdj[KEY_MIGRATION_PATTERN]
     param_obj[KEY_DEMOGRAPHICS_FILENAMES] = cdj[KEY_DEMOGRAPHICS_FILENAMES]
     param_obj[KEY_ROUNDTRIP_WAYPOINTS] = cdj.get(KEY_ROUNDTRIP_WAYPOINTS, 0)
-    print("*** param_obj ***")
-    print(param_obj)
+    #print("*** param_obj ***")
+    #print(param_obj)
     read_migration_params(param_obj, cdj, "Local")
     read_migration_params(param_obj, cdj, "Regional")
     read_migration_params(param_obj, cdj, "Air")
@@ -308,7 +304,7 @@ def create_report_file_stationary_distribution(param_obj, node_demog_df, report_
     migration_pattern = param_obj[KEY_MIGRATION_PATTERN]
     migration_model = param_obj[KEY_MIGRATION_MODEL]
     demog_filenames = param_obj[KEY_DEMOGRAPHICS_FILENAMES]
-
+    input_path = param_obj["input_directory"]
     success = True
 
     with open(report_name, "w") as outfile:
@@ -341,7 +337,7 @@ def create_report_file_stationary_distribution(param_obj, node_demog_df, report_
                 for migration_mode in ("Local", "Regional", "Air", "Sea"):
                     if param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].enable == 1:
                         outfile.write("Extracting data from {} migration...\n".format(migration_mode))
-                        migration_bin_json = read_migration_bin_json(os.path.join(INPUT_PATH, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename.__add__(".json")))
+                        migration_bin_json = read_migration_bin_json(os.path.join(input_path, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename.__add__(".json")))
                         if debug:
                             print("\tMigration bin json read: {}\n".format(str(migration_bin_json)))
                         if migration_bin_json['Metadata']['NodeCount'] != len(node_attributes):
@@ -352,7 +348,7 @@ def create_report_file_stationary_distribution(param_obj, node_demog_df, report_
                                                  len(node_attributes)))
                             success = False
 
-                        node_destination_rates = read_migration_bin(migration_mode, os.path.join(INPUT_PATH, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename))
+                        node_destination_rates = read_migration_bin(migration_mode, os.path.join(input_path, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename))
                         # DEVNOTE: ensure that node migration rate is as expected, note that if we use a generic rate validation, we should remove this check,
                         #          and add migration rate aggregation across all migration mode to get the real migration rate from Node i-> Node j
                         if debug:
@@ -531,6 +527,7 @@ def create_report_file(param_obj, node_demog_df, human_migration_df, report_name
     migration_pattern = param_obj[KEY_MIGRATION_PATTERN]
     migration_model = param_obj[KEY_MIGRATION_MODEL]
     demog_filenames = param_obj[KEY_DEMOGRAPHICS_FILENAMES]
+    input_path = param_obj["input_directory"]
 
     success = True
     with open(report_name, "w") as outfile:
@@ -566,7 +563,7 @@ def create_report_file(param_obj, node_demog_df, human_migration_df, report_name
                             human_migration_df[human_migration_df.IndividualID == individual_id].iloc[:, 0].diff()
                         """
 
-                        migration_bin_json = read_migration_bin_json(os.path.join(INPUT_PATH, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename.__add__(".json")))
+                        migration_bin_json = read_migration_bin_json(os.path.join(input_path, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename.__add__(".json")))
                         if debug:
                             print("\tMigration bin json read:")
                             print(str(migration_bin_json))
@@ -580,8 +577,8 @@ def create_report_file(param_obj, node_demog_df, human_migration_df, report_name
                                                  len(node_attributes)))
                             success = False
 
-                        outfile.write("about to read_migration_bin({}, {}) \n".format(migration_mode, os.path.join(INPUT_PATH, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename)))
-                        node_destination_rates = read_migration_bin(migration_mode, os.path.join(INPUT_PATH, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename))
+                        outfile.write("about to read_migration_bin({}, {}) \n".format(migration_mode, os.path.join(input_path, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename)))
+                        node_destination_rates = read_migration_bin(migration_mode, os.path.join(input_path, param_obj[KEY_MIGRATION_PARAM.format(migration_mode)].filename))
                         if debug:
                             print("\tMigration bin read:")
                             print(str(node_destination_rates))

--- a/Regression/shared_embedded_py_scripts/dtk_test/dtk_MigrationModel_Support.py
+++ b/Regression/shared_embedded_py_scripts/dtk_test/dtk_MigrationModel_Support.py
@@ -18,6 +18,7 @@ KEY_MIGRATION_MODEL = "Migration_Model"  # ("NO_MIGRATION" | "FIXED_RATE_MIGRATI
 KEY_MIGRATION_PATTERN = "Migration_Pattern"  # {"RANDOM_WALK_DIFFUSION" | "SINGLE_ROUND_TRIPS" | "WAYPOINTS_HOME" }
 KEY_ROUNDTRIP_WAYPOINTS = "Roundtrip_Waypoints"
 KEY_DEMOGRAPHICS_FILENAMES  = "Demographics_Filenames"
+KEY_INPUT_DIRECTORY = "input_directory"
 
 # following is for generic Migration parameters
 KEY_MIGRATION_ENABLE = "Enable_{}_Migration"
@@ -73,7 +74,7 @@ def load_emod_parameters(config_filename="config.json"):
         config = json.load(infile)
         cdj = config["parameters"]
     param_obj = {}
-    param_obj["input_directory"] = config["input_directory"]
+    param_obj[KEY_INPUT_DIRECTORY] = config[KEY_INPUT_DIRECTORY]
     param_obj[KEY_TOTAL_TIMESTEPS] = cdj[KEY_TOTAL_TIMESTEPS]
     param_obj[KEY_SIMULATION_TIMESTEP] = cdj[KEY_SIMULATION_TIMESTEP]
     param_obj[KEY_MIGRATION_MODEL] = cdj[KEY_MIGRATION_MODEL]
@@ -304,7 +305,7 @@ def create_report_file_stationary_distribution(param_obj, node_demog_df, report_
     migration_pattern = param_obj[KEY_MIGRATION_PATTERN]
     migration_model = param_obj[KEY_MIGRATION_MODEL]
     demog_filenames = param_obj[KEY_DEMOGRAPHICS_FILENAMES]
-    input_path = param_obj["input_directory"]
+    input_path = param_obj[KEY_INPUT_DIRECTORY]
     success = True
 
     with open(report_name, "w") as outfile:
@@ -527,7 +528,7 @@ def create_report_file(param_obj, node_demog_df, human_migration_df, report_name
     migration_pattern = param_obj[KEY_MIGRATION_PATTERN]
     migration_model = param_obj[KEY_MIGRATION_MODEL]
     demog_filenames = param_obj[KEY_DEMOGRAPHICS_FILENAMES]
-    input_path = param_obj["input_directory"]
+    input_path = param_obj[KEY_INPUT_DIRECTORY]
 
     success = True
     with open(report_name, "w") as outfile:


### PR DESCRIPTION
adding "input_directory" parameter so dtk_MigrationModel_Support can find the migration files being used in the sim again after the sim is done.

sfts(fix affects Generic/SFTs/MigrationModel tests): https://jenkins.apps.idmod.org/job/EMOD_Builds/job/scons_linux_all_sfts/105/
regression tests(shouldn't be affected): https://jenkins.apps.idmod.org/job/EMOD_Builds/job/scons_linux_all_regression/147/